### PR TITLE
Simplify cache model: centralize keys, remove bypass, add Force Refresh

### DIFF
--- a/mergecalweb/calendars/cache.py
+++ b/mergecalweb/calendars/cache.py
@@ -1,0 +1,9 @@
+from uuid import UUID
+
+
+def calendar_output_cache_key(uuid: UUID | str) -> str:
+    return f"calendar_str_{uuid}"
+
+
+def source_data_cache_key(url: str) -> str:
+    return f"calendar_data_{url}"

--- a/mergecalweb/calendars/cache.py
+++ b/mergecalweb/calendars/cache.py
@@ -1,4 +1,11 @@
+import logging
 from uuid import UUID
+
+from django.core.cache import cache
+
+from mergecalweb.core.logging_events import LogEvent
+
+logger = logging.getLogger(__name__)
 
 
 def calendar_output_cache_key(uuid: UUID | str) -> str:
@@ -7,3 +14,17 @@ def calendar_output_cache_key(uuid: UUID | str) -> str:
 
 def source_data_cache_key(url: str) -> str:
     return f"calendar_data_{url}"
+
+
+def invalidate_calendar_cache(calendar) -> None:
+    cache.delete(calendar_output_cache_key(calendar.uuid))
+    for source in calendar.calendarOf.all():
+        cache.delete(source_data_cache_key(source.url))
+    logger.info(
+        "Cache invalidated",
+        extra={
+            "event": LogEvent.CACHE_INVALIDATED,
+            "calendar_uuid": calendar.uuid,
+            "calendar_name": calendar.name,
+        },
+    )

--- a/mergecalweb/calendars/cache.py
+++ b/mergecalweb/calendars/cache.py
@@ -17,9 +17,11 @@ def source_data_cache_key(url: str) -> str:
 
 
 def invalidate_calendar_cache(calendar) -> None:
-    cache.delete(calendar_output_cache_key(calendar.uuid))
-    for source in calendar.calendarOf.all():
-        cache.delete(source_data_cache_key(source.url))
+    keys = [calendar_output_cache_key(calendar.uuid)]
+    keys.extend(
+        source_data_cache_key(source.url) for source in calendar.calendarOf.all()
+    )
+    cache.delete_many(keys)
     logger.info(
         "Cache invalidated",
         extra={

--- a/mergecalweb/calendars/fetching/fetcher.py
+++ b/mergecalweb/calendars/fetching/fetcher.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import requests
 from django.core.cache import cache
 
+from mergecalweb.calendars.cache import source_data_cache_key
 from mergecalweb.calendars.fetching.domain_configs import get_domain_config
 from mergecalweb.core.logging_events import LogEvent
 
@@ -38,7 +39,7 @@ class CalendarFetcher:
         Raises:
             requests.RequestException: If fetch fails and no stale cache available
         """
-        cache_key = f"calendar_data_{url}"
+        cache_key = source_data_cache_key(url)
         cached_data = cache.get(cache_key)
 
         if cached_data is not None:

--- a/mergecalweb/calendars/merger.py
+++ b/mergecalweb/calendars/merger.py
@@ -5,6 +5,7 @@ import httpx
 from django.core.cache import cache
 from icalendar import Calendar as ICalendar
 
+from mergecalweb.calendars.cache import source_data_cache_key
 from mergecalweb.calendars.models import Source
 
 logger = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ class SoucreService:
 
     def _fetch_calendar(self) -> None:
         url = self.url
-        cache_key = f"calendar_data_{url}"
+        cache_key = source_data_cache_key(url)
         cached_data = cache.get(cache_key)
 
         if cached_data is not None:

--- a/mergecalweb/calendars/models.py
+++ b/mergecalweb/calendars/models.py
@@ -3,14 +3,12 @@ import logging
 import typing
 import uuid
 import zoneinfo
-from datetime import timedelta
 from urllib.parse import urlencode
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
-from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from icalendar import Calendar as Ical
 from requests.exceptions import RequestException
@@ -29,8 +27,6 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 TWELVE_HOURS_IN_SECONDS = 43200
-CACHE_BYPASS_HOURS = 3  # Hours to disable CDN cache after calendar modification
-MIN_BYPASS_CACHE_TTL_SECONDS = 30  # Server cache TTL during bypass (30 sec)
 MAX_ERROR_MESSAGE_LENGTH = 200  # Maximum length for error messages shown to users
 
 
@@ -288,40 +284,11 @@ class Calendar(TimeStampedModel):
 
     @property
     def effective_cache_ttl(self):
-        """
-        Get the effective server-side cache TTL in seconds.
-        During cache bypass period, returns 30 seconds for quick server-side updates.
-        This is separate from CDN caching which is disabled (max-age=0) during bypass.
-        Otherwise returns the user's configured update frequency.
-        """
-        if self.is_in_cache_bypass_period():
-            return MIN_BYPASS_CACHE_TTL_SECONDS
         return self.effective_update_frequency
 
     @property
     def show_branding(self):
         return not (self.remove_branding and self.owner.can_remove_branding)
-
-    def is_in_cache_bypass_period(self):
-        """
-        Check if calendar is in the cache bypass period defined by CACHE_BYPASS_HOURS.
-        After saving/modifying a calendar, CDN cache is disabled and server cache
-        is reduced to 30 seconds for CACHE_BYPASS_HOURS hours so users can see
-        their changes quickly (like Cloudflare dev mode).
-        """
-        bypass_threshold = timezone.now() - timedelta(hours=CACHE_BYPASS_HOURS)
-        return self.modified > bypass_threshold
-
-    def get_cache_bypass_end_time(self):
-        """
-        Get the datetime when the cache bypass period ends.
-        The duration of the bypass period is determined by the CACHE_BYPASS_HOURS constant.
-        Returns None if not in bypass period.
-        """
-        if not self.is_in_cache_bypass_period():
-            return None
-
-        return self.modified + timedelta(hours=CACHE_BYPASS_HOURS)
 
     def get_calendar_file_url(self):
         return reverse("calendars:calendar_file", kwargs={"uuid": self.uuid})

--- a/mergecalweb/calendars/services/calendar_merger_service.py
+++ b/mergecalweb/calendars/services/calendar_merger_service.py
@@ -11,6 +11,7 @@ from icalendar import Event
 from icalendar import vDuration
 from mergecal import CalendarMerger
 
+from mergecalweb.calendars.cache import calendar_output_cache_key
 from mergecalweb.calendars.models import Calendar
 from mergecalweb.core.logging_events import LogEvent
 
@@ -60,7 +61,7 @@ class CalendarMergerService:
             ical = self._add_tier_warnings()
             return ical.to_ical().decode("utf-8")
 
-        cache_key = f"calendar_str_{self.calendar.uuid}"
+        cache_key = calendar_output_cache_key(self.calendar.uuid)
         cached_calendar = cache.get(cache_key)
 
         if cached_calendar is not None:

--- a/mergecalweb/calendars/services/calendar_merger_service.py
+++ b/mergecalweb/calendars/services/calendar_merger_service.py
@@ -128,7 +128,6 @@ class CalendarMergerService:
                 "size_bytes": len(calendar_str),
                 "duration_seconds": round(merge_duration, 2),
                 "cache_ttl_seconds": cache_ttl,
-                "is_in_bypass_period": self.calendar.is_in_cache_bypass_period(),
             },
         )
 

--- a/mergecalweb/calendars/signals.py
+++ b/mergecalweb/calendars/signals.py
@@ -5,6 +5,7 @@ from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from mergecalweb.calendars.cache import calendar_output_cache_key
 from mergecalweb.calendars.models import Calendar
 from mergecalweb.calendars.models import Source
 from mergecalweb.core.logging_events import LogEvent
@@ -42,8 +43,7 @@ def clear_calendar_cache_on_source(sender, instance, **kwargs):
         )
         return
 
-    # Construct the cache key similar to how you set it
-    cache_key = f"calendar_str_{calendar.uuid}"
+    cache_key = calendar_output_cache_key(calendar.uuid)
 
     logger.info(
         "Source %s",
@@ -80,8 +80,7 @@ def clear_calendar_cache_on_source(sender, instance, **kwargs):
 @receiver(post_save, sender=Calendar)
 @receiver(post_delete, sender=Calendar)
 def clear_calendar_cache_on_calendar(sender, instance, **kwargs):
-    # Construct the cache key similar to how you set it
-    cache_key = f"calendar_str_{instance.uuid}"
+    cache_key = calendar_output_cache_key(instance.uuid)
 
     if kwargs.get("created") is not None:
         action = "created" if kwargs.get("created") else "updated"

--- a/mergecalweb/calendars/signals.py
+++ b/mergecalweb/calendars/signals.py
@@ -1,11 +1,10 @@
 import logging
 
-from django.core.cache import cache
 from django.db.models.signals import post_delete
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from mergecalweb.calendars.cache import calendar_output_cache_key
+from mergecalweb.calendars.cache import invalidate_calendar_cache
 from mergecalweb.calendars.models import Calendar
 from mergecalweb.calendars.models import Source
 from mergecalweb.core.logging_events import LogEvent
@@ -16,16 +15,16 @@ logger = logging.getLogger(__name__)
 @receiver(post_save, sender=Source)
 @receiver(post_delete, sender=Source)
 def clear_calendar_cache_on_source(sender, instance, **kwargs):
-    if kwargs.get("created") is not None:
-        action = "created" if kwargs.get("created") else "updated"
-    else:
-        action = "deleted"
+    action = (
+        "created"
+        if kwargs.get("created")
+        else ("deleted" if kwargs.get("created") is None else "updated")
+    )
 
     # When a Calendar is deleted, its Sources are cascade-deleted.
     # The post_delete signal fires after the Calendar is already gone,
     # so accessing instance.calendar raises Calendar.DoesNotExist.
-    # In this case, we skip cache invalidation here since the Calendar's
-    # own post_delete signal (clear_calendar_cache_on_calendar) will handle it.
+    # Skip here — the Calendar's own post_delete signal handles invalidation.
     try:
         calendar = instance.calendar
     except Calendar.DoesNotExist:
@@ -43,8 +42,6 @@ def clear_calendar_cache_on_source(sender, instance, **kwargs):
         )
         return
 
-    cache_key = calendar_output_cache_key(calendar.uuid)
-
     logger.info(
         "Source %s",
         action,
@@ -60,32 +57,17 @@ def clear_calendar_cache_on_source(sender, instance, **kwargs):
             "email": calendar.owner.email,
         },
     )
-
-    # Check if the cache exists and delete it
-    cache.delete(cache_key)
-    logger.info(
-        "Cache invalidated due to source change",
-        extra={
-            "event": LogEvent.CACHE_INVALIDATED,
-            "cache_reason": "source-change",
-            "cache_key": cache_key,
-            "source_id": instance.pk,
-            "source_name": instance.name,
-            "action": action,
-            "calendar_uuid": calendar.uuid,
-        },
-    )
+    invalidate_calendar_cache(calendar)
 
 
 @receiver(post_save, sender=Calendar)
 @receiver(post_delete, sender=Calendar)
 def clear_calendar_cache_on_calendar(sender, instance, **kwargs):
-    cache_key = calendar_output_cache_key(instance.uuid)
-
-    if kwargs.get("created") is not None:
-        action = "created" if kwargs.get("created") else "updated"
-    else:
-        action = "deleted"
+    action = (
+        "created"
+        if kwargs.get("created")
+        else ("deleted" if kwargs.get("created") is None else "updated")
+    )
 
     logger.info(
         "Calendar %s",
@@ -99,17 +81,4 @@ def clear_calendar_cache_on_calendar(sender, instance, **kwargs):
             "email": instance.owner.email,
         },
     )
-
-    # Check if the cache exists and delete it
-    cache.delete(cache_key)
-    logger.info(
-        "Cache invalidated due to calendar change",
-        extra={
-            "event": LogEvent.CACHE_INVALIDATED,
-            "cache_reason": "calendar-change",
-            "cache_key": cache_key,
-            "calendar_uuid": instance.uuid,
-            "calendar_name": instance.name,
-            "action": action,
-        },
-    )
+    invalidate_calendar_cache(instance)

--- a/mergecalweb/calendars/tests/test_models.py
+++ b/mergecalweb/calendars/tests/test_models.py
@@ -1,14 +1,10 @@
 import uuid
-from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 
-from mergecalweb.calendars.models import CACHE_BYPASS_HOURS
-from mergecalweb.calendars.models import MIN_BYPASS_CACHE_TTL_SECONDS
 from mergecalweb.calendars.models import Calendar
 from mergecalweb.calendars.models import Source
 from mergecalweb.users.models import User
@@ -146,70 +142,14 @@ class TestCalendarModel:
         cal_business.save()
         assert cal_business.effective_update_frequency == new_value
 
-    def test_cache_bypass_period_active(self, business_user: User) -> None:
-        """Test that calendar is in bypass period after modification."""
-        calendar = Calendar.objects.create(
-            name="Test Calendar",
-            owner=business_user,
-        )
-        # Calendar was just created, should be in bypass period
-        assert calendar.is_in_cache_bypass_period() is True
-        assert calendar.get_cache_bypass_end_time() is not None
-
-    def test_cache_bypass_period_expired(self, business_user: User) -> None:
-        """Test calendar not in bypass period after CACHE_BYPASS_HOURS."""
-        calendar = Calendar.objects.create(
-            name="Test Calendar",
-            owner=business_user,
-        )
-        # Manually set modified time to be older than bypass period using update()
-        # to avoid triggering auto_now which would reset modified to now()
-        old_time = timezone.now() - timedelta(hours=CACHE_BYPASS_HOURS + 1)
-        Calendar.objects.filter(pk=calendar.pk).update(modified=old_time)
-        calendar.refresh_from_db()
-
-        assert calendar.is_in_cache_bypass_period() is False
-        assert calendar.get_cache_bypass_end_time() is None
-
-    def test_cache_bypass_end_time_calculation(self, business_user: User) -> None:
-        """Test that cache bypass end time is calculated correctly."""
-        calendar = Calendar.objects.create(
-            name="Test Calendar",
-            owner=business_user,
-        )
-        end_time = calendar.get_cache_bypass_end_time()
-        expected_end = calendar.modified + timedelta(hours=CACHE_BYPASS_HOURS)
-
-        assert end_time is not None
-        # Allow 1 second tolerance for test execution time
-        assert abs((end_time - expected_end).total_seconds()) < 1
-
-    def test_effective_cache_ttl_during_bypass(self, business_user: User) -> None:
-        """Test that effective_cache_ttl returns 30 seconds during bypass."""
-        calendar = Calendar.objects.create(
-            name="Test Calendar",
-            owner=business_user,
-            update_frequency_seconds=7200,  # 2 hours
-        )
-        # Calendar just created, should be in bypass period
-        assert calendar.is_in_cache_bypass_period() is True
-        assert calendar.effective_cache_ttl == MIN_BYPASS_CACHE_TTL_SECONDS
-
-    def test_effective_cache_ttl_after_bypass(self, business_user: User) -> None:
-        """Test effective_cache_ttl returns normal frequency after bypass."""
+    def test_effective_cache_ttl(self, business_user: User) -> None:
+        """Test effective_cache_ttl returns the configured update frequency."""
         expected_ttl = 7200  # 2 hours
         calendar = Calendar.objects.create(
             name="Test Calendar",
             owner=business_user,
             update_frequency_seconds=expected_ttl,
         )
-        # Set modified time to be older than bypass period using update()
-        # to avoid triggering auto_now which would reset modified to now()
-        old_time = timezone.now() - timedelta(hours=CACHE_BYPASS_HOURS + 1)
-        Calendar.objects.filter(pk=calendar.pk).update(modified=old_time)
-        calendar.refresh_from_db()
-
-        assert calendar.is_in_cache_bypass_period() is False
         assert calendar.effective_cache_ttl == expected_ttl
 
 

--- a/mergecalweb/calendars/urls.py
+++ b/mergecalweb/calendars/urls.py
@@ -8,6 +8,7 @@ from mergecalweb.calendars.views import SourceAddView
 from mergecalweb.calendars.views import SourceEditView
 from mergecalweb.calendars.views import UserCalendarListView
 from mergecalweb.calendars.views import calendar_iframe
+from mergecalweb.calendars.views import calendar_refresh
 from mergecalweb.calendars.views import calendar_view
 from mergecalweb.calendars.views import source_delete
 
@@ -25,6 +26,7 @@ urlpatterns = [
         name="source_add",
     ),
     path("source/<int:pk>/delete/", source_delete, name="source_delete"),
+    path("<uuid:uuid>/refresh/", calendar_refresh, name="calendar_refresh"),
     path("<uuid>.ical", CalendarFileView.as_view(), name="calendar_file"),
     path("<uuid>.ics", CalendarFileView.as_view(), name="calendar_file_ics"),
     path("<uuid>/calendar/", calendar_view, name="calendar_view"),

--- a/mergecalweb/calendars/utils.py
+++ b/mergecalweb/calendars/utils.py
@@ -11,6 +11,7 @@ from icalendar import Calendar
 from icalendar import Timezone
 from icalendar import TimezoneStandard
 
+from mergecalweb.calendars.cache import calendar_output_cache_key
 from mergecalweb.calendars.meetup import fetch_and_create_meetup_calendar
 from mergecalweb.calendars.meetup import is_meetup_url
 from mergecalweb.core.logging_events import LogEvent
@@ -19,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 def combine_calendar(calendar_instance, origin_domain):
-    cal_bye_str = cache.get(f"calendar_str_{calendar_instance.uuid}")
+    cal_bye_str = cache.get(calendar_output_cache_key(calendar_instance.uuid))
     user = calendar_instance.owner
     if not user.is_free_tier or not cal_bye_str:
         if not user.is_free_tier:
@@ -104,7 +105,11 @@ def combine_calendar(calendar_instance, origin_domain):
         cal_bye_str = newcal.to_ical().decode("utf8")
         calendar_instance.calendar_file_str = cal_bye_str
         calendar_instance.save()
-        cache.set(f"calendar_str_{calendar_instance.uuid}", cal_bye_str, 60 * 60 * 24)
+        cache.set(
+            calendar_output_cache_key(calendar_instance.uuid),
+            cal_bye_str,
+            60 * 60 * 24,
+        )
         logger.info(
             "Deprecated: Calendar combined and saved",
             extra={

--- a/mergecalweb/calendars/views.py
+++ b/mergecalweb/calendars/views.py
@@ -25,7 +25,6 @@ from django.views.generic import UpdateView
 
 from mergecalweb.calendars.forms import CalendarForm
 from mergecalweb.calendars.forms import SourceForm
-from mergecalweb.calendars.models import CACHE_BYPASS_HOURS
 from mergecalweb.calendars.models import Calendar
 from mergecalweb.calendars.models import Source
 from mergecalweb.calendars.services.calendar_merger_service import CalendarMergerService
@@ -120,7 +119,6 @@ class CalendarUpdateView(LoginRequiredMixin, UpdateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["domain_name"] = get_site_url()
-        context["CACHE_BYPASS_HOURS"] = CACHE_BYPASS_HOURS
         return context
 
     def get_queryset(self):
@@ -369,17 +367,8 @@ class CalendarFileView(View):
         response = HttpResponse(calendar_str, content_type="text/calendar")
         response["Content-Disposition"] = f'attachment; filename="{uuid}.ics"'
 
-        # Set cache headers based on user's update frequency preference
-        # Optimized for Cloudflare CDN
-        # If calendar was modified in the last 3 hours, disable caching
-        # so users can see their changes immediately (like Cloudflare dev mode)
-        if calendar.is_in_cache_bypass_period():
-            # Disable cache for recently modified calendars
-            response["Cache-Control"] = "public, max-age=0, must-revalidate"
-        else:
-            # Use user's preferred cache TTL
-            cache_ttl = calendar.effective_update_frequency
-            response["Cache-Control"] = f"public, max-age={cache_ttl}"
+        cache_ttl = calendar.effective_update_frequency
+        response["Cache-Control"] = f"public, max-age={cache_ttl}"
 
         request_duration = time.time() - start_time
         logger.info(

--- a/mergecalweb/calendars/views.py
+++ b/mergecalweb/calendars/views.py
@@ -23,6 +23,7 @@ from django.views.generic import DeleteView
 from django.views.generic import ListView
 from django.views.generic import UpdateView
 
+from mergecalweb.calendars.cache import invalidate_calendar_cache
 from mergecalweb.calendars.forms import CalendarForm
 from mergecalweb.calendars.forms import SourceForm
 from mergecalweb.calendars.models import Calendar
@@ -387,6 +388,31 @@ class CalendarFileView(View):
         )
 
         return response
+
+
+@require_POST
+@login_required
+def calendar_refresh(request, uuid):
+    calendar = get_object_or_404(Calendar, uuid=uuid, owner=request.user)
+    user = request.user
+    logger.info(
+        "User force-refreshed calendar cache",
+        extra={
+            "event": LogEvent.CACHE_INVALIDATED,
+            "cache_reason": "user-force-refresh",
+            "user_id": user.pk,
+            "email": user.email,
+            "calendar_uuid": calendar.uuid,
+            "calendar_name": calendar.name,
+            "user_tier": user.subscription_tier,
+        },
+    )
+    invalidate_calendar_cache(calendar)
+    messages.success(
+        request,
+        "Done! Your calendar now shows the latest data from all your sources.",
+    )
+    return redirect("calendars:calendar_view", uuid=uuid)
 
 
 def calendar_view(request: HttpRequest, uuid: str) -> HttpResponse:

--- a/mergecalweb/templates/calendars/calendar_form.html
+++ b/mergecalweb/templates/calendars/calendar_form.html
@@ -42,12 +42,6 @@
             <form method="post" id="calendar-form">
               {% csrf_token %}
               {% crispy form %}
-              {% if calendar.pk %}
-                <div class="alert alert-info" role="alert">
-                  <i class="bi bi-info-circle me-2"></i>
-                  <strong>Note:</strong> Saving this calendar will disable caching for {{ CACHE_BYPASS_HOURS|default:"3" }} hours so you can see your changes immediately.
-                </div>
-              {% endif %}
               <button type="submit" class="btn btn-primary">Save Calendar</button>
               <a href="{% url 'calendars:calendar_list' %}" class="btn btn-secondary">Cancel</a>
             </form>
@@ -58,19 +52,6 @@
                 <span>UUID: {{ calendar.uuid }}</span>
                 <span>Last modified: {{ calendar.modified|date:"M d, Y H:i" }}</span>
               </small>
-              {% if calendar.is_in_cache_bypass_period %}
-                <div class="alert alert-info mt-2 mb-0 py-2" role="alert">
-                  <div class="d-flex align-items-center">
-                    <i class="bi bi-lightning-charge-fill me-2"></i>
-                    <div class="flex-grow-1">
-                      <strong>Cache Bypass Active</strong>
-                      <div class="small">
-                        Your calendar changes will appear immediately. Cache will be re-enabled at {{ calendar.get_cache_bypass_end_time|date:"g:i A" }} ({{ calendar.get_cache_bypass_end_time|timeuntil }} from now).
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              {% endif %}
             </div>
           {% endif %}
         </div>

--- a/mergecalweb/templates/calendars/calendar_view.html
+++ b/mergecalweb/templates/calendars/calendar_view.html
@@ -8,16 +8,29 @@
     <div class="row align-items-center mb-4">
       <div class="col-md-4">
         {% if user.is_authenticated %}
-          <a href="{% url 'calendars:calendar_list' %}"
-             class="btn btn-outline-primary me-2">
-            <i class="bi bi-arrow-left"></i> Back to My Calendars
-          </a>
-          {% if calendar.owner == user %}
-            <a href="{% url 'calendars:calendar_update' calendar.uuid %}"
-               class="btn btn-primary">
-              <i class="bi bi-pencil"></i> Edit Calendar
+          <div class="d-flex gap-2 flex-wrap">
+            <a href="{% url 'calendars:calendar_list' %}"
+               class="btn btn-outline-primary">
+              <i class="bi bi-arrow-left"></i> Back to My Calendars
             </a>
-          {% endif %}
+            {% if calendar.owner == user %}
+              <a href="{% url 'calendars:calendar_update' calendar.uuid %}"
+                 class="btn btn-primary">
+                <i class="bi bi-pencil"></i> Edit Calendar
+              </a>
+              <form method="post"
+                    action="{% url 'calendars:calendar_refresh' calendar.uuid %}">
+                {% csrf_token %}
+                <button type="submit"
+                        class="btn btn-outline-secondary"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="bottom"
+                        title="Your merged calendar is cached based on your update frequency. Click to clear the cache and re-fetch the latest data from all your sources immediately.">
+                  <i class="bi bi-arrow-clockwise"></i> Force Refresh
+                </button>
+              </form>
+            {% endif %}
+          </div>
         {% endif %}
       </div>
       <div class="col-md-4 text-center">


### PR DESCRIPTION
## Summary

- **Centralize cache keys** — introduce `calendar_output_cache_key()` and `source_data_cache_key()` in `calendars/cache.py` as the single source of truth, replacing 7 inline f-strings across the codebase
- **Remove 3-hour cache bypass** — delete `is_in_cache_bypass_period`, `get_cache_bypass_end_time`, `CACHE_BYPASS_HOURS`, `MIN_BYPASS_CACHE_TTL_SECONDS`, and all related view/template logic; `effective_cache_ttl` now simply returns `effective_update_frequency`
- **Add `invalidate_calendar_cache()` helper** — clears both the merged output cache and all per-source data caches for a calendar; signals now delegate to this single function instead of doing inline `cache.delete`
- **Force Refresh button** — owner-only POST endpoint at `/<uuid>/refresh/` on the calendar view page, with a tooltip explaining the cache behaviour

## Test plan

- [x] Click Force Refresh on the calendar view page as owner — calendar reloads with fresh data and success message appears
- [x] Confirm Force Refresh is not visible to non-owners or logged-out users
- [ ] Edit a calendar source and confirm cache is invalidated (signal path)
- [ ] Delete a source and confirm cache is invalidated
- [ ] Confirm `effective_cache_ttl` returns `effective_update_frequency` directly