### PR TITLE
Fix production logs showing as error severity in Railway

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -187,6 +187,7 @@ LOGGING = {
         "console": {
             "level": "DEBUG",
             "class": "logging.StreamHandler",
+            "stream": "ext://sys.stdout",
             "formatter": "json",
         },
     },


### PR DESCRIPTION
## Summary

- `logging.StreamHandler()` defaults to `sys.stderr` when no stream is specified
- Railway (and most log aggregators) classify all stderr output as `severity=error`, regardless of the actual log level
- This causes every log line — including `INFO` and `DEBUG` — to appear as error in Railway's log viewer

## Fix

Add `"stream": "ext://sys.stdout"` to the production console handler so logs go to stdout, which Railway correctly parses for severity.

## Test plan

- [ ] Deploy and check Railway logs — `INFO` logs should no longer show `severity: error`
- [ ] Confirm actual errors still show `severity: error` (they'll still log at ERROR level on stdout)
- [ ] Easy to revert: close this PR and redeploy if it doesn't fix it