### PR TITLE
Document agent environment setup and fix drifted AGENTS.md commands

### DIFF
--- a/.claude/web-session-setup.md
+++ b/.claude/web-session-setup.md
@@ -1,0 +1,43 @@
+# Claude Code Web Session Setup
+
+Remote Claude Code sessions run in a fresh container: the repo is cloned,
+but project dependencies are not installed and PostgreSQL is not running.
+Do this before running tests or management commands.
+
+## 1. Install dependencies
+
+```bash
+pip install -r requirements/local.txt
+```
+
+## 2. Start PostgreSQL and create the database
+
+Postgres is installed in the container but down. The default
+`DATABASE_URL` is `postgres:///mergecalweb` (unix socket, current OS user),
+so the current user needs a login role and the database must exist:
+
+```bash
+service postgresql start
+sudo -u postgres psql -c "CREATE ROLE $(whoami) SUPERUSER LOGIN;"
+sudo -u postgres createdb mergecalweb -O "$(whoami)"
+```
+
+Redis/Celery are NOT required for the test suite.
+
+## 3. Run tools through the project Python
+
+The `pytest` and `mypy` binaries on PATH may be isolated tool installs
+that cannot see the project's dependencies. Always invoke them as modules:
+
+```bash
+python -m pytest
+python -m mypy --config-file pyproject.toml mergecalweb config
+```
+
+## Known baseline failures (do not chase these)
+
+Verify your change against `main` before attributing failures to it:
+
+- `ruff check .` fails on `docs/conf.py` (PGH004) on a clean checkout.
+- mypy reports dozens of pre-existing errors on `main`. Compare error
+  counts against `main` rather than aiming for a clean run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 # Agent Handbook
+- Claude Code web session? Provision the container first: see `.claude/web-session-setup.md`.
 - MergeCal merges iCal feeds; Django 4+, Postgres, Redis, Celery.
 - Core app `mergecalweb/calendars/`: `models.py` enforces tier limits; `services/` orchestrate merging.
 - Calendars dedupe events by UID; cache duration varies per subscription tier.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,12 +3,14 @@
 - MergeCal merges iCal feeds; Django 4+, Postgres, Redis, Celery.
 - Core app `mergecalweb/calendars/`: `models.py` enforces tier limits; `services/` orchestrate merging.
 - Calendars dedupe events by UID; cache duration varies per subscription tier.
-- `calendar_merger_service.py` merges sources; `source_processor.py` validates feeds; `calendar_fetcher.py` pulls remote ICS.
+- `calendar_merger_service.py` merges sources; `source_processor.py` validates feeds; `fetching/fetcher.py` pulls remote ICS.
+- Cache pre-warming runs via `python manage.py prefetch_calendars` (cron), not Celery.
 - Meetup URLs handled in `meetup.py`; recursive MergeCal feeds are supported with existence checks.
 - `mergecalweb/users/` defines PERSONAL/BUSINESS/SUPPORTER tiers controlling calendar counts and feature access.
 - Branding opt-out and custom update cadence live behind Business/Supporter tiers.
 - Billing app integrates Stripe via dj-stripe; blog/core provide marketing content and shared utilities.
 - Settings live in `config/settings/`; Celery setup in `config/celery_app.py`; URLs in `config/urls.py`.
+- Periodic tasks are django-celery-beat rows in the DB (DatabaseScheduler), not defined in code.
 - Install deps: `pip install -r requirements/local.txt`.
 - Prep DB: `python manage.py migrate`; create admin via `python manage.py createsuperuser` when needed.
 - Run dev server: `python manage.py runserver`.
@@ -19,7 +21,8 @@
 - Coverage: `pytest --cov=mergecalweb`.
 - Lint: `ruff check .`; auto-fix `ruff check --fix`; format via `ruff format .`.
 - Templates: `djlint --reformat mergecalweb/templates/` then `djlint`.
-- Typing: `mypy --config-file pyproject.toml`; favor explicit annotations and `from __future__ import annotations`.
+- Typing: `mypy --config-file pyproject.toml mergecalweb config` (targets required); favor explicit annotations and `from __future__ import annotations`.
+- Lint/typing baseline is not clean on `main` (see `.claude/web-session-setup.md`); compare against `main` before fixing "your" errors.
 - Style: 4-space Python, 2-space templates, double quotes, avoid bare excepts; no Cursor/Copilot rule files.
 - Logging: Structured logging for filtering user journeys, billing flows, calendar operations:
   - ALWAYS: `extra={"event": LogEvent.CONSTANT, ...}` (import from `mergecalweb.core.logging_events`)


### PR DESCRIPTION
## Why

Agents (and humans) starting from a fresh clone hit avoidable friction: the documented mypy command fails as written, Postgres setup is assumed but undocumented, and a couple of architecture facts that shape decisions (cron-based cache pre-warming, beat schedules living in the DB) weren't written down anywhere. Each new Claude Code web session was rediscovering the same setup steps.

## What

- **New `.claude/web-session-setup.md`** — container provisioning checklist for Claude Code web sessions: install deps, start Postgres and create the role/database (default `DATABASE_URL` is `postgres:///mergecalweb` over the unix socket), run pytest/mypy via `python -m` since PATH binaries may be isolated tool installs, and known baseline lint/typing failures on `main` so sessions don't chase pre-existing errors. `AGENTS.md` points here for web sessions, keeping the handbook itself focused on the project.
- **AGENTS.md corrections** — mypy invocation now includes its required targets (`mergecalweb config`); stale `calendar_fetcher.py` reference updated to `fetching/fetcher.py`; documented that cache pre-warming runs via the `prefetch_calendars` cron command (not Celery) and that periodic tasks are django-celery-beat rows in the DB where code searches won't find them.

No code changes — documentation only.

https://claude.ai/code/session_01HPotpYu15bMzUGX7sjEfdr

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPotpYu15bMzUGX7sjEfdr)_