### PR TITLE
Suppress allauth "Unknown Account" emails

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -382,6 +382,11 @@ SOCIALACCOUNT_ADAPTER = "mergecalweb.users.adapters.SocialAccountAdapter"
 SOCIALACCOUNT_FORMS = {"signup": "mergecalweb.users.forms.UserSocialSignupForm"}
 # https://docs.allauth.org/en/latest/socialaccount/configuration.html
 ACCOUNT_LOGIN_BY_CODE_ENABLED = True
+# Suppress "Unknown Account" emails on login-by-code / password reset for
+# non-existent accounts. Enumeration prevention (fake code page) stays intact;
+# this only stops the outbound email that bots/typos were triggering in bulk.
+# https://docs.allauth.org/en/latest/account/configuration.html
+ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
 # https://docs.allauth.org/en/latest/socialaccount/configuration.html
 ACCOUNT_SIGNUP_FORM_HONEYPOT_FIELD = "phone_number"
 # django-compressor


### PR DESCRIPTION
## Problem

Users triggered 3+ `[MergeCal] Unknown Account` emails on a specific journey (visible in Mailjet dashboard). Root cause: `ACCOUNT_LOGIN_BY_CODE_ENABLED = True` plus allauth's default `EMAIL_UNKNOWN_ACCOUNTS = True`.

When someone submits an email with **no account** to the login-by-code / password-reset flow, allauth's enumeration prevention shows a fake "enter code" page **and** sends an `Unknown Account` email. The code page has a Resend button that re-fires the mail, so confused users (never getting a code, since no account exists) click resend → 3+ emails each.

Bots and typos hitting the login-code endpoint sent these in bulk → Mailjet flagged and **suspended** the sending account.

## Fix

Set `ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False`.

- No more `Unknown Account` emails; resend clicks send nothing.
- Enumeration prevention (fake code page) stays intact — no account leak.
- Login-by-code for **real** accounts unaffected.

## Follow-ups (not in this PR)

- Ask Mailjet to lift the suspension once volume drops.
- Rate-limit the login-code endpoint to stop bot abuse at the source.

Assistant-model: Claude Code